### PR TITLE
Add Levenshtein Distance Matching

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -24,6 +24,13 @@ var result = data.filter(fuzzy("dan"));
 console.log(result);
 // [{
 // 		name: "Dan Smith"
+// }]	
+
+result = data.filter(fuzzy("dun", 1));
+	
+console.log(result);
+// [{
+// 		name: "Dan Smith"
 // }]
 ```
 
@@ -144,11 +151,12 @@ This time, `result` would contain only one element:
 Documentation
 ------------
 
-**fuzzy(query, keys)**  
+**fuzzy(query, keys, leven)**  
 Returns a filter predicate (function) suitable for passing to [`Array.prototype.filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter).
 
 * `query`: The filter query to use to reduce an array down to objects matching the query. This can be a string or a number.
 * `keys`: Optionally restrict the search to a set of keys; only applied when filtering objects. This can be a string containing the name of a single key, or an array of keys.
+* `leven`: The (levenshtein distance](http://en.wikipedia.org/wiki/Levenshtein_distance) used to consider matches. This means that differences such as "Dan" and "Dun" can be tolerated. This is a number that determines the levenshtein threshold.
 
 ### Normalization
 What makes this a "fuzzy" filter is that it is looking for values that _somewhat_ match the query—not exact matches.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "author": "Daniel Pfeiffer",
   "repository": "mediabounds/fuzzy-predicate",
   "license": "MIT",
+  "dependencies": {
+    "leven": "^2.1.0"
+  },
   "devDependencies": {
     "eslint": "^3.13.1",
     "eslint-config-google": "^0.6.0",

--- a/test/test.js
+++ b/test/test.js
@@ -106,6 +106,12 @@ describe("fuzzy-predicate", function() {
       results = haystack.filter(fuzzy("JOHN_DOE"));
       assert.deepStrictEqual(results, ["John Doe", "To John Doe", "john-doe"]);
     });
+    
+    it("matches strings containing the query using levenshtein distance", function() {
+      var results = haystack.filter(fuzzy("Jane",{leven: 2}));
+      assert.deepStrictEqual(results, ["Jane Smith"]);
+    });
+
   });
 
   context("given an array of numbers", function() {

--- a/test/test.js
+++ b/test/test.js
@@ -107,8 +107,8 @@ describe("fuzzy-predicate", function() {
       assert.deepStrictEqual(results, ["John Doe", "To John Doe", "john-doe"]);
     });
     
-    it("matches strings containing the query using levenshtein distance", function() {
-      var results = haystack.filter(fuzzy("Jane",{leven: 2}));
+    it("matches strings containing the query using given levenshtein distance", function() {
+      var results = haystack.filter(fuzzy("Jaine", 1));
       assert.deepStrictEqual(results, ["Jane Smith"]);
     });
 


### PR DESCRIPTION
Add the ability to specify a levenshtein distance to consider matches. This allows for a truly fuzzy match.  eg: "David" can match "Dabid" making it useful on matching data that has typos.