### PR TITLE
feat(Matching): Use Dice Coefficient Algorithm to compare strings

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -24,6 +24,13 @@ var result = data.filter(fuzzy("dan"));
 console.log(result);
 // [{
 // 		name: "Dan Smith"
+// }]	
+
+result = data.filter(fuzzy("dun", 1));
+	
+console.log(result);
+// [{
+// 		name: "Dan Smith"
 // }]
 ```
 
@@ -144,11 +151,12 @@ This time, `result` would contain only one element:
 Documentation
 ------------
 
-**fuzzy(query, keys)**  
+**fuzzy(query, keys, leven)**  
 Returns a filter predicate (function) suitable for passing to [`Array.prototype.filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter).
 
 * `query`: The filter query to use to reduce an array down to objects matching the query. This can be a string or a number.
 * `keys`: Optionally restrict the search to a set of keys; only applied when filtering objects. This can be a string containing the name of a single key, or an array of keys.
+* `leven`: The (levenshtein distance](http://en.wikipedia.org/wiki/Levenshtein_distance) used to consider matches. This means that differences such as "Dan" and "Dun" can be tolerated. This is a number that determines the levenshtein threshold.
 
 ### Normalization
 What makes this a "fuzzy" filter is that it is looking for values that _somewhat_ match the query—not exact matches.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -26,7 +26,7 @@ console.log(result);
 // 		name: "Dan Smith"
 // }]	
 
-result = data.filter(fuzzy("dun", 1));
+result = data.filter(fuzzy("dun", 0.2));
 	
 console.log(result);
 // [{

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -156,7 +156,7 @@ Returns a filter predicate (function) suitable for passing to [`Array.prototype.
 
 * `query`: The filter query to use to reduce an array down to objects matching the query. This can be a string or a number.
 * `keys`: Optionally restrict the search to a set of keys; only applied when filtering objects. This can be a string containing the name of a single key, or an array of keys.
-* `leven`: The (levenshtein distance](http://en.wikipedia.org/wiki/Levenshtein_distance) used to consider matches. This means that differences such as "Dan" and "Dun" can be tolerated. This is a number that determines the levenshtein threshold.
+* `threshold`: The [Dice's Coefficient](https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient) threshold used to consider matches. This means that differences such as "In my camp Dan has a fire" and "Dun has fire" can be tolerated. It's a fraction between 0 and 1, which indicates the degree of similarity between the needle and haystack. 0 indicates completely different strings, 1 indicates identical strings.
 
 ### Normalization
 What makes this a "fuzzy" filter is that it is looking for values that _somewhat_ match the query—not exact matches.
@@ -166,7 +166,7 @@ When comparing strings, the needle (the query) and the haystack value are both n
 1. Convert the string to a lowercase string
 2. Remove all non-word characters (characters matching the `\W` regex and underscores)
 
-Then, instead of checking string equality, it checks to see if the haystack value contains the needle value (using `indexOf`). If it does, it's considered a match.
+Then, instead of checking string equality, it checks to see if the haystack value contains the needle value (using `indexOf`). If it does, it's considered a match. If threshold is supplied, then a [Dice's Coefficient](https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient) algorithm is used to compare the degree of difference between the needle and haystack and if it's above or equal to the threshold then it's a match.
 
 This process only applies when comparing strings; numbers must be exactly equal to be considered a match.
 
@@ -179,3 +179,7 @@ Contributing
 I welcome pull requests containing bug fixes and documentation improvements for `fuzzy-predicate`. Be sure to run the tests before submitting any changes.
 
 And although I consider `fuzzy-predicate` to be _mostly_ feature complete, I welcome discussion on how it could be a more useful tool (e.g. if callers could customize how normalization worked).
+
+Contributors
+------------
+[Emmanuel Mahuni](https://github.com/emahuni) - Added Dice algorithm option for truly fuzzy matches

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "author": "Daniel Pfeiffer",
   "repository": "mediabounds/fuzzy-predicate",
   "license": "MIT",
+  "dependencies": {
+    "leven": "^2.1.0"
+  },
   "devDependencies": {
     "eslint": "^3.13.1",
     "eslint-config-google": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "repository": "mediabounds/fuzzy-predicate",
   "license": "MIT",
   "dependencies": {
-    "leven": "^2.1.0"
+    "string-similarity": "^3.0.0"
   },
   "devDependencies": {
     "eslint": "^3.13.1",

--- a/test/test.js
+++ b/test/test.js
@@ -106,6 +106,12 @@ describe("fuzzy-predicate", function() {
       results = haystack.filter(fuzzy("JOHN_DOE"));
       assert.deepStrictEqual(results, ["John Doe", "To John Doe", "john-doe"]);
     });
+    
+    it("matches strings containing the query using levenshtein distance", function() {
+      var results = haystack.filter(fuzzy("Jane",{leven: 2}));
+      assert.deepStrictEqual(results, ["Jane Smith"]);
+    });
+
   });
 
   context("given an array of numbers", function() {

--- a/test/test.js
+++ b/test/test.js
@@ -107,8 +107,8 @@ describe("fuzzy-predicate", function() {
       assert.deepStrictEqual(results, ["John Doe", "To John Doe", "john-doe"]);
     });
     
-    it("matches strings containing the query using levenshtein distance", function() {
-      var results = haystack.filter(fuzzy("Jane",{leven: 2}));
+    it("matches strings containing the query using given levenshtein distance", function() {
+      var results = haystack.filter(fuzzy("Jaine", 1));
       assert.deepStrictEqual(results, ["Jane Smith"]);
     });
 


### PR DESCRIPTION
Add the ability to specify a similarity threshold to consider matches. This allows for a truly fuzzy match.  eg: "David" can match "Dabid was here" making it useful on matching data that has typos or different in syntax and order of words.